### PR TITLE
Add AI chat Gutenberg block boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# tldrwp
-A WP plugin to allow viewers of a post click an AI button to generate a TLDR summary with your custom CTA messaging. 
+# TLDRWP AI Block
+
+This plugin provides a basic boilerplate for creating dynamic Gutenberg blocks that interact with the [AI Services](https://wordpress.org/plugins/ai-services/) plugin. A simple "AI Chat" block is included which displays an input field and sends the prompt to the server via a REST request. The response is generated through a filter so you can connect any AI provider supported by the AI Services plugin.
+
+## Features
+
+- Dynamic Gutenberg block registered via `register_block_type`.
+- Front‑end interaction with a REST API endpoint for AI requests.
+- Dependency on the **AI Services** plugin so site owners can choose their preferred AI backend.
+
+## Usage
+
+1. Install and activate the **AI Services** plugin.
+2. Upload or clone this plugin into your WordPress `wp-content/plugins` directory and activate it.
+3. Insert the **AI Chat** block into a post or page.
+4. On the front end, enter a prompt and click **Ask AI** to see the response.
+
+Developers can hook into the `tldrwp_generate_ai_response` filter to send the prompt to any supported AI service.

--- a/blocks/ai-chat/index.js
+++ b/blocks/ai-chat/index.js
@@ -1,0 +1,37 @@
+( function( blocks, element ) {
+    var el = element.createElement;
+    blocks.registerBlockType( 'tldrwp/ai-chat', {
+        title: 'AI Chat',
+        icon: 'robot',
+        category: 'widgets',
+        edit: function() {
+            return el( 'p', {}, 'AI Chat block – displays on the front end.' );
+        },
+        save: function() {
+            return null; // Dynamic block
+        }
+    } );
+} )( window.wp.blocks, window.wp.element );
+
+document.addEventListener( 'click', function( e ) {
+    if ( ! e.target.classList.contains( 'tldrwp-submit' ) ) {
+        return;
+    }
+
+    var container = e.target.closest( '#tldrwp-ai-chat' );
+    var prompt    = container.querySelector( '.tldrwp-prompt' ).value;
+    var output    = container.querySelector( '.tldrwp-output' );
+
+    wp.apiFetch( {
+        path: '/tldrwp/v1/chat',
+        method: 'POST',
+        data: {
+            prompt: prompt,
+            nonce: e.target.dataset.nonce
+        }
+    } ).then( function( res ) {
+        output.textContent = res.response || 'No response';
+    } ).catch( function( err ) {
+        output.textContent = 'Error: ' + err.message;
+    } );
+} );

--- a/blocks/ai-chat/style.css
+++ b/blocks/ai-chat/style.css
@@ -1,0 +1,6 @@
+#tldrwp-ai-chat {
+    margin: 1em 0;
+}
+.tldrwp-ai-chat .tldrwp-output {
+    margin-bottom: 0.5em;
+}

--- a/tldrwp.php
+++ b/tldrwp.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Plugin Name: TLDRWP AI Block
+ * Description: Basic WordPress plugin boilerplate with a dynamic Gutenberg block that interacts with the AI Services plugin.
+ * Version: 0.1.0
+ * Author: OpenAI Codex
+ * Requires Plugins: ai-services
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
+ * License: GPLv2 or later
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Check if the AI Services plugin is active.
+ */
+function tldrwp_check_ai_services() {
+    if ( ! function_exists( 'is_plugin_active' ) ) {
+        require_once ABSPATH . 'wp-admin/includes/plugin.php';
+    }
+    if ( ! is_plugin_active( 'ai-services/ai-services.php' ) ) {
+        add_action( 'admin_notices', function() {
+            echo '<div class="notice notice-error"><p>' . esc_html__( 'TLDRWP requires the AI Services plugin to be installed and active.', 'tldrwp' ) . '</p></div>';
+        } );
+        return false;
+    }
+    return true;
+}
+
+add_action( 'init', 'tldrwp_register_block' );
+
+/**
+ * Register the dynamic block and scripts.
+ */
+function tldrwp_register_block() {
+    if ( ! tldrwp_check_ai_services() ) {
+        return;
+    }
+
+    wp_register_script(
+        'tldrwp-block',
+        plugins_url( 'blocks/ai-chat/index.js', __FILE__ ),
+        array( 'wp-blocks', 'wp-element', 'wp-editor', 'wp-components', 'wp-api-fetch' ),
+        filemtime( plugin_dir_path( __FILE__ ) . 'blocks/ai-chat/index.js' )
+    );
+
+    wp_register_style(
+        'tldrwp-block',
+        plugins_url( 'blocks/ai-chat/style.css', __FILE__ ),
+        array(),
+        filemtime( plugin_dir_path( __FILE__ ) . 'blocks/ai-chat/style.css' )
+    );
+
+    register_block_type( 'tldrwp/ai-chat', array(
+        'editor_script'   => 'tldrwp-block',
+        'editor_style'    => 'tldrwp-block',
+        'style'           => 'tldrwp-block',
+        'render_callback' => 'tldrwp_render_ai_chat_block',
+    ) );
+}
+
+/**
+ * Render callback for the dynamic block.
+ */
+function tldrwp_render_ai_chat_block( $attributes, $content ) {
+    ob_start();
+    ?>
+    <div id="tldrwp-ai-chat" class="tldrwp-ai-chat">
+        <div class="tldrwp-output"></div>
+        <input type="text" class="tldrwp-prompt" placeholder="<?php esc_attr_e( 'Ask me anything...', 'tldrwp' ); ?>">
+        <button class="tldrwp-submit" data-nonce="<?php echo esc_attr( wp_create_nonce( 'tldrwp_nonce' ) ); ?>">
+            <?php esc_html_e( 'Ask AI', 'tldrwp' ); ?>
+        </button>
+    </div>
+    <?php
+    return ob_get_clean();
+}
+
+add_action( 'rest_api_init', 'tldrwp_register_rest_routes' );
+
+/**
+ * Register REST API endpoint for AI interaction.
+ */
+function tldrwp_register_rest_routes() {
+    register_rest_route( 'tldrwp/v1', '/chat', array(
+        'methods'             => 'POST',
+        'callback'            => 'tldrwp_handle_chat_request',
+        'permission_callback' => function() { return wp_verify_nonce( $_POST['nonce'] ?? '', 'tldrwp_nonce' ); },
+    ) );
+}
+
+/**
+ * Handle the AI chat request via AI Services plugin.
+ */
+function tldrwp_handle_chat_request( WP_REST_Request $request ) {
+    if ( ! tldrwp_check_ai_services() ) {
+        return new WP_REST_Response( array( 'error' => __( 'AI Services plugin is not active.', 'tldrwp' ) ), 400 );
+    }
+
+    $prompt = sanitize_text_field( $request->get_param( 'prompt' ) );
+
+    /**
+     * Filter to generate content using AI Services.
+     * Developers using different AI services can hook into this filter.
+     */
+    $response = apply_filters( 'tldrwp_generate_ai_response', '', $prompt );
+
+    return rest_ensure_response( array( 'response' => $response ) );
+}


### PR DESCRIPTION
## Summary
- add basic WP plugin skeleton
- create dynamic AI Chat block
- integrate with AI Services via REST API filter
- document usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68754d2096488330bfc6461f0a6bdad8